### PR TITLE
Track label events in label taxonomy meta

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /_build
 /vendor
 /.vscode
+/.idea
 
 # Files
 .DS_Store

--- a/core.ghactivity.php
+++ b/core.ghactivity.php
@@ -1,26 +1,34 @@
 <?php
 /**
- * GHActivity calls to GitHub API
- *
- * https://developer.github.com/v3/
+ * GHActivity calls to GitHub API https://developer.github.com/v3/
  *
  * @since 1.0
  */
 
-defined( 'ABSPATH' ) or die( 'No script kiddies please!' );
+defined( 'ABSPATH' ) || die( 'No script kiddies please!' );
+
+require_once 'ghapi.ghactivity.php';
 
 /**
  * GitHub API Calls
  *
  * @since 1.0
  */
-class GHActivity_Calls {
 
-	function __construct() {
+class GHActivity_Calls {
+	/**
+	 * API_Calls module which is in charge of sending HTTP requests to GitHub.
+	 *
+	 * @var API_Calls instance of API_Calls
+	 */
+	private $api;
+
+	public function __construct() {
 		add_action( 'ghactivity_publish', array( $this, 'publish_event' ) );
 		if ( ! wp_next_scheduled( 'ghactivity_publish' ) ) {
 			wp_schedule_event( time(), 'hourly', 'ghactivity_publish' );
 		}
+		$this->api = new API_Calls();
 	}
 
 	/**
@@ -40,154 +48,6 @@ class GHActivity_Calls {
 		} else {
 			return '';
 		}
-	}
-
-	/**
-	 * Remote call to get data from GitHub's API.
-	 *
-	 * @since 1.0
-	 *
-	 * @return null|array
-	 */
-	private function get_github_activity() {
-
-		$response_body = array();
-
-		/**
-		 * Create an array of usernames.
-		 * I try to account for single usernames, comma separated lists, space separated lists, and comma + space lists.
-		 */
-		$usernames = array_filter( preg_split( '/[,\s]+/', $this->get_option( 'username' ) ) );
-
-		// Loop through that array and make a request to the GitHub API for each person.
-		foreach ( $usernames as $username ) {
-			$query_url = sprintf(
-				'https://api.github.com/users/%1$s/events?access_token=%2$s',
-				$username,
-				$this->get_option( 'access_token' )
-			);
-
-			$data = wp_remote_get( esc_url_raw( $query_url ) );
-
-			if (
-				is_wp_error( $data )
-				|| 200 != $data['response']['code']
-				|| empty( $data['body'] )
-			) {
-				continue;
-			}
-
-			$single_response_body = json_decode( $data['body'] );
-
-			$response_body = array_merge( $single_response_body, $response_body );
-		}
-
-		// If we have repos to watch, let's get data for them.
-		$repos_to_monitor = $this->get_monitored_repos( 'names' );
-		if ( ! empty( $repos_to_monitor ) ) {
-			foreach ( $repos_to_monitor as $repo ) {
-				$repo_activity = $this->get_repo_activity( $repo );
-				// If we got data from those repos, add it to the existing list of events.
-				if ( isset( $repo_activity ) && is_array( $repo_activity ) ) {
-					$response_body = array_merge( $repo_activity, $response_body );
-				}
-			}
-		}
-
-		// Finally return the response.
-		return $response_body;
-	}
-
-	/**
-	 * Remote call to get data for a specific repo
-	 *
-	 * @since 1.6.0
-	 *
-	 * @param string $repo_name Name of the repo we want data from.
-	 *
-	 * @return null|array
-	 */
-	private function get_repo_activity( $repo_name ) {
-
-		$response_body = array();
-
-		if ( empty( $repo_name ) ) {
-			return $response_body;
-		}
-
-		$query_url = sprintf(
-			'https://api.github.com/repos/%1$s/events?access_token=%2$s',
-			esc_html( $repo_name ),
-			$this->get_option( 'access_token' )
-		);
-
-		$data = wp_remote_get( esc_url_raw( $query_url ) );
-
-		if (
-			is_wp_error( $data )
-			|| 200 != $data['response']['code']
-			|| empty( $data['body'] )
-		) {
-			return $response_body;
-		}
-
-		$response_body = json_decode( $data['body'] );
-
-		return $response_body;
-	}
-
-	/**
-	 * Remote call to get information about a specific GitHub user.
-	 *
-	 * @since 1.6.0
-	 *
-	 * @param string $gh_username GitHub username.
-	 *
-	 * @return array $gh_user_details Details about a GitHub user.
-	 */
-	private function get_person_details( $gh_username = '' ) {
-		$gh_user_details = array();
-
-		if ( empty( $gh_username ) ) {
-			return $gh_user_details;
-		}
-
-		// Let's get some info from GitHub.
-		$query_url = sprintf(
-			'https://api.github.com/users/%1$s?access_token=%2$s',
-			$gh_username,
-			$this->get_option( 'access_token' )
-		);
-		$data = wp_remote_get( esc_url_raw( $query_url ) );
-
-		if (
-			is_wp_error( $data )
-			|| 200 != $data['response']['code']
-			|| empty( $data['body'] )
-		) {
-			return $gh_user_details;
-		}
-
-		$person_info_body = json_decode( $data['body'] );
-
-		/**
-		 * Let's build a name based on the name field.
-		 * If it is not defined, fall back to username.
-		 */
-		if ( ! empty( $person_info_body->name ) ) {
-			$nicename = $person_info_body->name;
-		} else {
-			$nicename = $person_info_body->login;
-		}
-
-		// Build the array of data we will save.
-		$gh_user_details = array(
-			'name'       => esc_html( $nicename ),
-			'avatar_url' => esc_url( $person_info_body->avatar_url ),
-			'bio'        => esc_html( $person_info_body->bio ),
-		);
-
-		return $gh_user_details;
 	}
 
 	/**
@@ -263,6 +123,7 @@ class GHActivity_Calls {
 	 * Get an event type to use as a taxonomy, and in the post content.
 	 *
 	 * Starts from data collected with GitHub API, and displays a nice event type instead.
+	 *
 	 * @see https://developer.github.com/v3/activity/events/types/
 	 *
 	 * @since 1.0
@@ -273,37 +134,37 @@ class GHActivity_Calls {
 	 * @return string $ghactivity_event_type Event type displayed in ghactivity_event_type taxonomy.
 	 */
 	private function get_event_type( $event_type, $action ) {
-		if ( 'IssuesEvent' == $event_type ) {
-			if ( 'closed' == $action ) {
+		if ( 'IssuesEvent' === $event_type ) {
+			if ( 'closed' === $action ) {
 				$ghactivity_event_type = __( 'Issue Closed', 'ghactivity' );
-			} elseif ( 'opened' == $action ) {
+			} elseif ( 'opened' === $action ) {
 				$ghactivity_event_type = __( 'Issue Opened', 'ghactivity' );
 			} else {
 				$ghactivity_event_type = __( 'Issue touched', 'ghactivity' );
 			}
-		} elseif ( 'PullRequestEvent' == $event_type ) {
-			if ( 'closed' == $action ) {
+		} elseif ( 'PullRequestEvent' === $event_type ) {
+			if ( 'closed' === $action ) {
 				$ghactivity_event_type = __( 'PR Closed', 'ghactivity' );
-			} elseif ( 'opened' == $action ) {
+			} elseif ( 'opened' === $action ) {
 				$ghactivity_event_type = __( 'PR Opened', 'ghactivity' );
 			} else {
 				$ghactivity_event_type = __( 'PR touched', 'ghactivity' );
 			}
-		} elseif ( 'IssueCommentEvent' == $event_type || 'CommitCommentEvent' == $event_type ) {
+		} elseif ( 'IssueCommentEvent' === $event_type || 'CommitCommentEvent' === $event_type ) {
 			$ghactivity_event_type = __( 'Comment', 'ghactivity' );
-		} elseif ( 'PullRequestReviewCommentEvent' == $event_type ) {
+		} elseif ( 'PullRequestReviewCommentEvent' === $event_type ) {
 			$ghactivity_event_type = __( 'Reviewed a PR', 'ghactivity' );
-		} elseif ( 'PushEvent' == $event_type ) {
+		} elseif ( 'PushEvent' === $event_type ) {
 			$ghactivity_event_type = __( 'Pushed a branch', 'ghactivity' );
-		} elseif ( 'CreateEvent' == $event_type ) {
+		} elseif ( 'CreateEvent' === $event_type ) {
 			$ghactivity_event_type = __( 'Created a tag', 'ghactivity' );
-		} elseif ( 'ReleaseEvent' == $event_type ) {
+		} elseif ( 'ReleaseEvent' === $event_type ) {
 			$ghactivity_event_type = __( 'Created a release', 'ghactivity' );
-		} elseif ( 'DeleteEvent' == $event_type ) {
+		} elseif ( 'DeleteEvent' === $event_type ) {
 			$ghactivity_event_type = __( 'Deleted a branch' );
-		} elseif ( 'GollumEvent' == $event_type ) {
+		} elseif ( 'GollumEvent' === $event_type ) {
 			$ghactivity_event_type = __( 'Edited a Wiki page' );
-		} elseif ( 'ForkEvent' == $event_type ) {
+		} elseif ( 'ForkEvent' === $event_type ) {
 			$ghactivity_event_type = __( 'Forked a repo' );
 		} else {
 			$ghactivity_event_type = __( 'Did something', 'ghactivity' );
@@ -343,31 +204,31 @@ class GHActivity_Calls {
 			return '';
 		}
 
-		if ( 'IssuesEvent' == $event->type ) {
+		if ( 'IssuesEvent' === $event->type ) {
 			$link = $event->payload->issue->html_url;
-		} elseif ( 'PullRequestEvent' == $event->type ) {
+		} elseif ( 'PullRequestEvent' === $event->type ) {
 			$link = $event->payload->pull_request->html_url;
 		} elseif (
-			'IssueCommentEvent' == $event->type
-			|| 'CommitCommentEvent' == $event->type
-			|| 'PullRequestReviewCommentEvent' == $event->type
+			'IssueCommentEvent' === $event->type
+			|| 'CommitCommentEvent' === $event->type
+			|| 'PullRequestReviewCommentEvent' === $event->type
 		) {
 			$link = $event->payload->comment->html_url;
-		} elseif ( 'PushEvent' == $event->type ) {
+		} elseif ( 'PushEvent' === $event->type ) {
 			$link = sprintf(
 				'https://github.com/%1$s/commits/%2$s',
 				esc_attr( $event->repo->name ),
 				esc_attr( $event->payload->head )
 			);
-		} elseif ( 'CreateEvent' == $event->type ) {
+		} elseif ( 'CreateEvent' === $event->type ) {
 			$link = sprintf(
 				'https://github.com/%1$s/tree/%2$s',
 				esc_attr( $event->repo->name ),
 				esc_attr( $event->payload->ref )
 			);
-		} elseif ( 'ReleaseEvent' == $event->type ) {
+		} elseif ( 'ReleaseEvent' === $event->type ) {
 			$link = $event->payload->release->html_url;
-		} elseif ( 'ForkEvent' == $event->type ) {
+		} elseif ( 'ForkEvent' === $event->type ) {
 			$link = $event->payload->forkee->html_url;
 		} else {
 			$link = '';
@@ -401,189 +262,188 @@ class GHActivity_Calls {
 	 * @since 1.0
 	 */
 	public function publish_event() {
-
-		$github_events = $this->get_github_activity();
+		$github_events = $this->api->get_github_activity();
 
 		/**
 		 * Only go through the event list if we have valid event array.
 		 */
-		if ( isset( $github_events ) && is_array( $github_events ) ) {
+		if ( ! isset( $github_events ) || ! is_array( $github_events ) ) {
+			return;
+		}
 
-			foreach ( $github_events as $event ) {
-				// Let's not keep private events if you don't want to save them.
-				if (
-					false == $event->public
-					&& true != $this->get_option( 'display_private' )
-				) {
+		foreach ( $github_events as $event ) {
+			// Let's not keep private events if you don't want to save them.
+			if (
+				false === $event->public
+				&& true !== $this->get_option( 'display_private' )
+			) {
+				continue;
+			}
+
+			// Continue looping if post exists with that ID, if not - let's go on and publish a post.
+			if ( ! is_null( get_page_by_title( $event->id, OBJECT, 'ghactivity_event' ) ) ) {
+				continue;
+			}
+
+			// Avoid errors when no action is attached to the event.
+			$action = '';
+			$meta   = false;
+
+			if ( isset( $event->payload->action ) ) {
+				$action = $event->payload->action;
+			}
+
+			// Create taxonomies.
+			$taxonomies = array(
+				'ghactivity_event_type' => esc_html( $this->get_event_type( $event->type, $action ) ),
+				'ghactivity_repo'       => esc_html( $event->repo->name ),
+				'ghactivity_actor'      => esc_html( $event->actor->display_login ),
+			);
+
+			// Build Post Content.
+			$post_content = $this->get_event_link( $event, $action );
+
+			if ( 'PushEvent' === $event->type ) {
+				// Store the number of commits attached to the event in post meta.
+				$meta = array( '_github_commits' => absint( $event->payload->distinct_size ) );
+				// Mention the number of commits if there are any.
+				$post_content .= sprintf(
+					__( ', including %1$s commits.', 'ghactivity' ), $meta['_github_commits']
+				);
+			}
+
+			/**
+			 * Small interlude: let's record info in the ghactivity_issue CPT
+			 * if the event is about an issue or PR.
+			 */
+			if (
+				(
+					'PullRequestEvent' === $event->type
+					|| 'IssuesEvent' === $event->type
+					|| 'IssueCommentEvent' === $event->type
+					|| 'PullRequestReviewCommentEvent' === $event->type
+				)
+				&& (
+					! empty( $event->payload->issue )
+					|| ! empty( $event->payload->pull_request )
+				)
+				&& (
+					in_array(
+						$event->repo->name,
+						/**
+						 * Allow site owners to only log issues for specific repos.
+						 *
+						 * @since 2.0.0
+						 *
+						 * @param array $repos Array of repos for which we want to monitor events.
+						 */
+						apply_filters( 'ghactivity_issues_repo_to_monitor', $this->get_monitored_repos( 'names' ) )
+					)
+				)
+			) {
+				// Is it an issue or a PR?
+				if ( ! empty( $event->payload->pull_request ) ) {
+					$issue_type = 'pull_request';
+					$created_at = $event->payload->pull_request->created_at;
+					$state      = $event->payload->pull_request->state;
+					$title      = esc_html( $event->payload->pull_request->title );
+					$labels     = ( isset( $event->payload->pull_request->labels ) ? $this->get_label_names( $event->payload->pull_request->labels ) : array() );
+					$number     = $event->payload->pull_request->number;
+				} else {
+					$issue_type = 'issue';
+					$created_at = $event->payload->issue->created_at;
+					$state      = $event->payload->issue->state;
+					$title      = esc_html( $event->payload->issue->title );
+					$labels     = ( isset( $event->payload->issue->labels ) ? $this->get_label_names( $event->payload->issue->labels ) : array() );
+					$number     = $event->payload->issue->number;
+				}
+
+				/**
+				 * Specify a creator when an issue or PR is opened.
+				 * Favorize display_login when possible.
+				 */
+				$creator = '';
+				if ( 'opened' === $event->payload->action ) {
+					$creator = esc_html( $event->actor->display_login );
+				} elseif ( ! empty( $event->payload->pull_request ) ) {
+					$creator = esc_html( $event->payload->pull_request->user->login );
+				} elseif ( ! empty( $event->payload->issue ) ) {
+					$creator = esc_html( $event->payload->issue->user->login );
+				}
+
+				// Record event.
+				$issue_details = array(
+					'type'       => $issue_type,
+					'event_type' => $taxonomies['ghactivity_event_type'],
+					'created_at' => $created_at,
+					'number'     => ( ! empty( $number ) ? absint( $number ) : 0 ),
+					'repo_name'  => esc_html( $event->repo->name ),
+					'state'      => ( isset( $state ) ? esc_html( $state ) : 'open' ),
+					'title'      => $title,
+					'comments'   => ( isset( $event->payload->comments ) ? $event->payload->comments : 0 ),
+					'creator'    => $creator,
+					'labels'     => $labels,
+				);
+				$this->record_issue_details( $issue_details );
+			}
+
+			// Finally, publish our event.
+			$event_args = array(
+				'post_title'   => $event->id,
+				'post_type'    => 'ghactivity_event',
+				'post_status'  => 'publish',
+				'post_date'    => $event->created_at,
+				'tax_input'    => $taxonomies,
+				'meta_input'   => $meta,
+				'post_content' => $post_content,
+			);
+			$post_id    = wp_insert_post( $event_args );
+
+			/**
+			 * Establish the relationship between terms and taxonomies.
+			 */
+			foreach ( $taxonomies as $taxonomy => $value ) {
+				$term_taxonomy_ids = wp_set_object_terms( $post_id, $value, $taxonomy, true );
+				if ( ! is_array( $term_taxonomy_ids ) || empty( $term_taxonomy_ids ) ) {
 					continue;
 				}
 
-				// If no post exists with that ID, let's go on and publish a post.
-				if ( is_null( get_page_by_title( $event->id, OBJECT, 'ghactivity_event' ) ) ) {
-					// Store the number of commits attached to the event in post meta.
-					if ( 'PushEvent' == $event->type ) {
-						$meta = array( '_github_commits' => absint( $event->payload->distinct_size ) );
-					} else {
-						$meta = false;
-					}
-
-					// Avoid errors when no action is attached to the event.
-					if ( isset( $event->payload->action ) ) {
-						$action = $event->payload->action;
-					} else {
-						$action = '';
-					}
-
-					// Create taxonomies.
-					$taxonomies = array(
-						'ghactivity_event_type' => esc_html( $this->get_event_type( $event->type, $action ) ),
-						'ghactivity_repo'       => esc_html( $event->repo->name ),
-						'ghactivity_actor'      => esc_html( $event->actor->display_login ),
-					);
-
-					// Build Post Content.
-					$post_content = $this->get_event_link( $event, $action );
-
-					// Mention the number of commits if there are any.
-					if ( $meta ) {
-						$post_content .= sprintf(
-							__( ', including %1$s commits.', 'ghactivity' ),
-							$meta['_github_commits']
-						);
-					}
-
+				/**
+				 * Since wp_set_object_terms returned an array of term_taxonomy_ids after running,
+				 * we can use it to add more info to each term.
+				 * From Term taxonomy IDs, we'll get term IDs.
+				 * Then from there, we'll update the term and add a description and additional information if needed.
+				 */
+				foreach ( $term_taxonomy_ids as $term_taxonomy_id ) {
 					/**
-					 * Small interlude: let's record info in the ghactivity_issue CPT
-					 * if the event is about an issue or PR.
+					 * Let's search for people without info attached to their profile.
+					 * We'll try to get that info from GitHub.
 					 */
+					$term_id_object = get_term_by( 'term_taxonomy_id', $term_taxonomy_id, 'ghactivity_actor', ARRAY_A );
+					$term_id        = (int) $term_id_object['term_id'];
 					if (
-						(
-							'PullRequestEvent' === $event->type
-							|| 'IssuesEvent' === $event->type
-							|| 'IssueCommentEvent' === $event->type
-							|| 'PullRequestReviewCommentEvent' === $event->type
-						)
-						&& (
-							! empty( $event->payload->issue )
-							|| ! empty( $event->payload->pull_request )
-						)
-						&& (
-							in_array(
-								$event->repo->name,
-								/**
-								 * Allow site owners to only log issues for specific repos.
-								 *
-								 * @since 2.0.0
-								 *
-								 * @param array $repos Array of repos for which we want to monitor events.
-								 */
-								apply_filters( 'ghactivity_issues_repo_to_monitor', $this->get_monitored_repos( 'names' ) )
-							)
-						)
+						is_array( $term_id_object )
+						&& 'ghactivity_actor' === $term_id_object['taxonomy']
+						&& empty( get_term_meta( $term_id, 'github_info', true ) )
 					) {
-						// Is it an issue or a PR?
-						if ( ! empty( $event->payload->pull_request ) ) {
-							$issue_type = 'pull_request';
-							$created_at = $event->payload->pull_request->created_at;
-							$state      = $event->payload->pull_request->state;
-							$title      = esc_html( $event->payload->pull_request->title );
-							$labels     = ( isset( $event->payload->pull_request->labels ) ? $this->get_label_names( $event->payload->pull_request->labels ) : array() );
-							$number     = $event->payload->pull_request->number;
-						} else {
-							$issue_type = 'issue';
-							$created_at = $event->payload->issue->created_at;
-							$state      = $event->payload->issue->state;
-							$title      = esc_html( $event->payload->issue->title );
-							$labels     = ( isset( $event->payload->issue->labels ) ? $this->get_label_names( $event->payload->issue->labels ) : array() );
-							$number     = $event->payload->issue->number;
-						}
+						$gh_user_details = $this->api->get_person_details( $term_id_object['name'] );
+						if ( ! empty( $gh_user_details ) ) {
+							// Add a bio and change the nice name.
+							$person_args = array(
+								'name'        => esc_html( $gh_user_details['name'] ),
+								'description' => esc_html( $gh_user_details['bio'] ),
+							);
+							wp_update_term( $term_id, 'ghactivity_actor', $person_args );
 
-						/**
-						 * Specify a creator when an issue or PR is opened.
-						 * Favorize display_login when possible.
-						 */
-						if ( 'opened' === $event->payload->action ) {
-							$creator = esc_html( $event->actor->display_login );
-						} elseif ( ! empty( $event->payload->pull_request ) ) {
-							$creator = esc_html( $event->payload->pull_request->user->login );
-						} elseif ( ! empty( $event->payload->issue ) ) {
-							$creator = esc_html( $event->payload->issue->user->login );
-						} else {
-							$creator = '';
+							// Save all the info as term meta.
+							update_term_meta( $term_id, 'github_info', $gh_user_details );
 						}
-
-						// Record event.
-						$issue_details = array(
-							'type'       => $issue_type,
-							'event_type' => $taxonomies['ghactivity_event_type'],
-							'created_at' => $created_at,
-							'number'     => ( ! empty( $number ) ? absint( $number ) : 0 ),
-							'repo_name'  => esc_html( $event->repo->name ),
-							'state'      => ( isset( $state ) ? esc_html( $state ) : 'open' ),
-							'title'      => $title,
-							'comments'   => ( isset( $event->payload->comments ) ? $event->payload->comments : 0 ),
-							'creator'    => $creator,
-							'labels'     => $labels,
-						);
-						$this->record_issue_details( $issue_details );
 					}
-
-					// Finally, publish our event.
-					$event_args = array(
-						'post_title'   => $event->id,
-						'post_type'    => 'ghactivity_event',
-						'post_status'  => 'publish',
-						'post_date'    => $event->created_at,
-						'tax_input'    => $taxonomies,
-						'meta_input'   => $meta,
-						'post_content' => $post_content,
-					);
-					$post_id = wp_insert_post( $event_args );
-
-					/**
-					 * Establish the relationship between terms and taxonomies.
-					 */
-					foreach ( $taxonomies as $taxonomy => $value ) {
-						$term_taxonomy_ids = wp_set_object_terms( $post_id, $value, $taxonomy, true );
-
-						/**
-						 * Since wp_set_object_terms returned an array of term_taxonomy_ids after running,
-						 * we can use it to add more info to each term.
-						 * From Term taxonomy IDs, we'll get term IDs.
-						 * Then from there, we'l update the term and add a description and additional information if needed.
-						 */
-						if ( is_array( $term_taxonomy_ids ) && ! empty( $term_taxonomy_ids ) ) {
-							foreach ( $term_taxonomy_ids as $term_taxonomy_id ) {
-								/**
-								 * Let's search for people without info attached to their profile.
-								 * We'll try to get that info from GitHub.
-								 */
-								$term_id_object = get_term_by( 'term_taxonomy_id', $term_taxonomy_id, 'ghactivity_actor', ARRAY_A );
-								$term_id = (int) $term_id_object['term_id'];
-								if (
-									is_array( $term_id_object )
-									&& 'ghactivity_actor' === $term_id_object['taxonomy']
-									&& empty( get_term_meta( $term_id, 'github_info', true ) )
-								) {
-									$gh_user_details = $this->get_person_details( $term_id_object['name'] );
-									if ( ! empty( $gh_user_details ) ) {
-										// Add a bio and change the nice name.
-										$person_args = array(
-											'name'        => esc_html( $gh_user_details['name'] ),
-											'description' => esc_html( $gh_user_details['bio'] ),
-										);
-										wp_update_term( $term_id, 'ghactivity_actor', $person_args );
-
-										// Save all the info as term meta.
-										update_term_meta( $term_id, 'github_info', $gh_user_details );
-									}
-								}
-							}
-						}
-					} // End foreach().
 				}
-			}
+			} // End foreach().
 		}
+
+		$this->update_issue_labels();
 	}
 
 	/**
@@ -592,17 +452,17 @@ class GHActivity_Calls {
 	 * @since 2.0.0
 	 *
 	 * @param array $issue_details {
-	 * 	Array of information about the issue.
-	 * 		@type string $type       issue or pull_request.
-	 * 		@type string $event_type What kind of event was this.
-	 * 		@type string created_at  When did this happen.
-	 * 		@type int    $number     Issue Number.
-	 * 		@type string $repo_name  Repo name.
-	 * 		@type string $state      Issue state (open or closed).
-	 * 		@type string $title      Issue title.
-	 * 		@type int    $comments   Number of comments on the issue.
-	 * 		@type string $creator    Issue creator.
-	 * 		@type array  $labels     Array of labels for that issue.
+	 * Array of information about the issue.
+	 *  @type string $type       issue or pull_request.
+	 *  @type string $event_type What kind of event was this.
+	 *  @type string created_at  When did this happen.
+	 *  @type int    $number     Issue Number.
+	 *  @type string $repo_name  Repo name.
+	 *  @type string $state      Issue state (open or closed).
+	 *  @type string $title      Issue title.
+	 *  @type int    $comments   Number of comments on the issue.
+	 *  @type string $creator    Issue creator.
+	 *  @type array  $labels     Array of labels for that issue.
 	 * }
 	 */
 	private function record_issue_details( $issue_details ) {
@@ -611,37 +471,27 @@ class GHActivity_Calls {
 		 * Update the post if not.
 		 * We make a WP_Query and set $is_new to help us figure this out.
 		 */
-		$is_new_args = array(
-			'post_type'      => 'ghactivity_issue',
-			'post_status'    => 'publish',
-			'posts_per_page' => 1,
-			'tax_query'      => array(
-				array(
-					'taxonomy' => 'ghactivity_repo',
-					'field'    => 'name',
-					'terms'    => $issue_details['repo_name'],
-				),
-			),
-			'meta_query' => array(
-				array(
-					'key'     => 'number',
-					'value'   => $issue_details['number'],
-					'compare' => '=',
-				),
-			),
+		$post_id = $this->find_post( $issue_details['repo_name'], $issue_details['number'] );
+		$meta = array(
+			'number'   => absint( $issue_details['number'] ),
+			'comments' => absint( $issue_details['comments'] ),
 		);
-		$query = new WP_Query( $is_new_args );
-		if ( $query->have_posts() ) {
-			$query->the_post();
 
-			$is_new = false;
-			$post_id = $query->post->ID;
-		} else {
-			$is_new = true;
-		}
-		wp_reset_postdata();
+		$post_content = sprintf(
+			'<ul>
+				<li><a href="https://github.com/%1$s/issues/%2$s">%3$s</a></li>
+				<li>%4$s %5$s</li>
+				<li>Comments: %6$s</li>
+			</ul>',
+			esc_attr( $issue_details['repo_name'] ),
+			absint( $issue_details['number'] ),
+			esc_html__( 'View original issue.', 'ghactivity' ),
+			esc_html__( 'Labels:', 'ghactivity' ),
+			implode( ', ', $issue_details['labels'] ),
+			absint( $issue_details['comments'] )
+		);
 
-		if ( $is_new ) {
+		if ( ! $post_id ) {
 			// Create taxonomies.
 			$taxonomies = array(
 				'ghactivity_repo'          => $issue_details['repo_name'],
@@ -651,24 +501,6 @@ class GHActivity_Calls {
 				'ghactivity_issues_type'   => $issue_details['type'],
 			);
 
-			$meta = array(
-				'number'   => absint( $issue_details['number'] ),
-				'comments' => absint( $issue_details['comments'] ),
-			);
-
-			$post_content = sprintf(
-				'<ul>
-					<li><a href="https://github.com/%1$s/issues/%2$s">%3$s</a></li>
-					<li>%4$s %5$s</li>
-					<li>Comments: %6$s</li>
-				</ul>',
-				esc_attr( $issue_details['repo_name'] ),
-				absint( $issue_details['number'] ),
-				esc_html__( 'View original issue.', 'ghactivity' ),
-				esc_html__( 'Labels:', 'ghactivity' ),
-				implode( ', ', $issue_details['labels'] ),
-				absint( $issue_details['comments'] )
-			);
 			$issue_args = array(
 				'post_title'   => $issue_details['title'],
 				'post_type'    => 'ghactivity_issue',
@@ -678,35 +510,11 @@ class GHActivity_Calls {
 				'meta_input'   => $meta,
 				'post_content' => $post_content,
 			);
-			$post_id = wp_insert_post( $issue_args );
-
-			/**
-			 * Establish the relationship between terms and taxonomies.
-			 */
-			foreach ( $taxonomies as $taxonomy => $value ) {
-				$term_taxonomy_ids = wp_set_object_terms( $post_id, $value, $taxonomy, true );
-			}
+			$post_id    = wp_insert_post( $issue_args );
 		} else {
 			$taxonomies = array(
 				'ghactivity_issues_state'  => $issue_details['state'],
 				'ghactivity_issues_labels' => $issue_details['labels'],
-			);
-			$meta = array(
-				'number'   => absint( $issue_details['number'] ),
-				'comments' => absint( $issue_details['comments'] ),
-			);
-			$post_content = sprintf(
-				'<ul>
-					<li><a href="https://github.com/%1$s/issues/%2$s">%3$s</a></li>
-					<li>%4$s %5$s</li>
-					<li>Comments: %6$s</li>
-				</ul>',
-				esc_attr( $issue_details['repo_name'] ),
-				absint( $issue_details['number'] ),
-				esc_html__( 'View original issue.', 'ghactivity' ),
-				esc_html__( 'Labels:', 'ghactivity' ),
-				implode( ', ', $issue_details['labels'] ),
-				absint( $issue_details['comments'] )
 			);
 
 			$issue_args = array(
@@ -717,14 +525,14 @@ class GHActivity_Calls {
 				'post_content' => $post_content,
 			);
 			wp_update_post( $issue_args );
-
-			/**
-			 * Establish the relationship between terms and taxonomies.
-			 */
-			foreach ( $taxonomies as $taxonomy => $value ) {
-				$term_taxonomy_ids = wp_set_object_terms( $post_id, $value, $taxonomy, false );
-			}
 		} // End if() $is_new.
+
+		/**
+		 * Establish the relationship between terms and taxonomies.
+		 */
+		foreach ( $taxonomies as $taxonomy => $value ) {
+			$term_taxonomy_ids = wp_set_object_terms( $post_id, $value, $taxonomy, true );
+		}
 	}
 
 	/**
@@ -1033,6 +841,91 @@ class GHActivity_Calls {
 		wp_reset_postdata();
 
 		return (int) count( $repos );
+	}
+
+	/**
+	 * Record any label updates into taxonomy meta of issue post.
+	 *
+	 * @since 2.1
+	 */
+	public function update_issue_labels() {
+		$event_list = $this->api->get_github_issue_events();
+
+		if ( ! isset( $event_list ) || ! is_array( $event_list ) ) {
+			return;
+		}
+
+		// Sorts all the events by created date from older to newer.
+		usort($event_list, function( $a, $b ) {
+			return ( strtotime( $a->created_at ) < strtotime( $b->created_at ) ) ? -1 : 1;
+		} );
+
+		foreach ( $event_list as $event ) {
+			// process only labeled & unlabeled event types.
+			if ( 'labeled' !== $event->event && 'unlabeled' !== $event->event ) {
+				continue;
+			}
+
+			preg_match( '/(?<=repos\/)(.*?)(?=\/issues)/', $event->url, $match );
+			$issue_number = $event->issue->number;
+			$repo_name    = $match[0];
+			$post_id      = $this->find_post( $repo_name, $issue_number );
+			if ( ! $post_id ) {
+				continue;
+			}
+
+			// Add missing labels if needed.
+			wp_set_object_terms( $post_id, $event->label->name, 'ghactivity_issues_labels', true );
+			$terms = wp_get_post_terms( $post_id, 'ghactivity_issues_labels' );
+
+			// update term metadata keys: status, unlabeled, labeled.
+			foreach ( $terms as $term ) {
+				if ( $term->name === $event->label->name ) {
+					update_term_meta( $term->term_id, 'status', $event->event );
+					update_term_meta( $term->term_id, $event->event, $event->created_at );
+				}
+			}
+		}
+	}
+
+	/**
+	 * Search for a exisiting `ghactivity_issue` post
+	 * Return post_id if found, and null if not.
+	 *
+	 * @param string $repo_name name of the repo.
+	 * @param int    $issue_number issue number.
+	 *
+	 * @return int $post_id ID of the post. Null if not found.
+	 */
+	public function find_post( $repo_name, $issue_number ) {
+		$post_id     = null;
+		$is_new_args = array(
+			'post_type'      => 'ghactivity_issue',
+			'post_status'    => 'publish',
+			'posts_per_page' => 1,
+			'tax_query'      => array(
+				array(
+					'taxonomy' => 'ghactivity_repo',
+					'field'    => 'name',
+					'terms'    => $repo_name,
+				),
+			),
+			'meta_query' => array(
+				array(
+					'key'     => 'number',
+					'value'   => $issue_number,
+					'compare' => '=',
+				),
+			),
+		);
+		$query = new WP_Query( $is_new_args );
+		if ( $query->have_posts() ) {
+			$query->the_post();
+			$post_id = $query->post->ID;
+		}
+		wp_reset_postdata();
+
+		return $post_id;
 	}
 }
 new GHActivity_Calls();

--- a/ghapi.ghactivity.php
+++ b/ghapi.ghactivity.php
@@ -1,0 +1,265 @@
+<?php
+/**
+ * Wrapper functions for GitHub API: https://developer.github.com/v3/
+ *
+ * @since 2.0
+ */
+
+defined( 'ABSPATH' ) || die( 'No script kiddies please!' );
+
+/**
+ * GitHub API Calls
+ *
+ * @since 2.0
+ */
+class API_Calls {
+	/**
+	 * Get option saved in the plugin's settings screen.
+	 *
+	 * @since 1.0
+	 *
+	 * @param string $name Option name.
+	 *
+	 * @return string $str Specific option.
+	 */
+	private function get_option( $name ) {
+		$options = get_option( 'ghactivity' );
+
+		if ( isset( $options[ $name ] ) ) {
+			return $options[ $name ];
+		} else {
+			return '';
+		}
+	}
+
+	/**
+	 * Get an array of repos we want to follow a bit more closely.
+	 * For those repos we will log activity from everyone,
+	 * not just from the usernames set in the plugin options.
+	 *
+	 * We will select all repos from the ghactivity_repo taxonomy,
+	 * and monitor all those that have the `full_reporting` term meta set to true.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param string $fields Type of info to return. Accept full or names. Default to full.
+	 *
+	 * @return WP_Error|array $repos_to_monitor Array of repos to monitor.
+	 */
+	public function get_monitored_repos( $fields = 'full' ) {
+		$repos_query_args = array(
+			'taxonomy'   => 'ghactivity_repo',
+			'hide_empty' => false,
+			'number'     => 10, // Just to make sure we don't get rate-limited by GH.
+			'fields'     => 'id=>name',
+			'meta_query' => array(
+				array(
+					'key'     => 'full_reporting',
+					'value'   => true,
+					'compare' => '=',
+				),
+			),
+		);
+		$repos_to_monitor = get_terms( $repos_query_args );
+
+		if ( 'full' === $fields ) {
+			return $repos_to_monitor;
+		} else {
+			$repo_names = array();
+			if (
+				! is_wp_error( $repos_to_monitor )
+				&& is_array( $repos_to_monitor )
+				&& ! empty( $repos_to_monitor )
+			) {
+				foreach ( $repos_to_monitor as $id => $name ) {
+					$repo_names[] = $name;
+				}
+			}
+			return $repo_names;
+		}
+	}
+
+	/**
+	 * Remote call to get data from GitHub's API.
+	 *
+	 * @since 1.0
+	 *
+	 * @return null|array
+	 */
+	public function get_github_activity() {
+		$response_body = array();
+
+		/**
+		 * Create an array of usernames.
+		 * I try to account for single usernames, comma separated lists, space separated lists, and comma + space lists.
+		 */
+		$usernames = array_filter( preg_split( '/[,\s]+/', $this->get_option( 'username' ) ) );
+
+		// Loop through that array and make a request to the GitHub API for each person.
+		foreach ( $usernames as $username ) {
+			$query_url = sprintf(
+				'https://api.github.com/users/%1$s/events?access_token=%2$s',
+				$username,
+				$this->get_option( 'access_token' )
+			);
+
+			$data = wp_remote_get( esc_url_raw( $query_url ) );
+
+			if (
+				is_wp_error( $data )
+				|| 200 !== $data['response']['code']
+				|| empty( $data['body'] )
+			) {
+				continue;
+			}
+			$single_response_body = json_decode( $data['body'] );
+			$response_body        = array_merge( $single_response_body, $response_body );
+		}
+
+		// If we have repos to watch, let's get data for them.
+		$repos_to_monitor = $this->get_monitored_repos( 'names' );
+		if ( ! empty( $repos_to_monitor ) ) {
+			foreach ( $repos_to_monitor as $repo ) {
+				$repo_activity = self::get_repo_activity( $repo );
+				// If we got data from those repos, add it to the existing list of events.
+				if ( isset( $repo_activity ) && is_array( $repo_activity ) ) {
+					$response_body = array_merge( $repo_activity, $response_body );
+				}
+			}
+		}
+
+		// Finally return the response.
+		return $response_body;
+	}
+
+	/**
+	 * Remote call to get data for a specific repo
+	 *
+	 * @since 1.6.0
+	 *
+	 * @param string $repo_name Name of the repo we want data from.
+	 *
+	 * @return null|array
+	 */
+	public function get_repo_activity( $repo_name ) {
+
+		$response_body = array();
+
+		if ( empty( $repo_name ) ) {
+			return $response_body;
+		}
+
+		$query_url = sprintf(
+			'https://api.github.com/repos/%1$s/events?access_token=%2$s',
+			esc_html( $repo_name ),
+			$this->get_option( 'access_token' )
+		);
+
+		$data = wp_remote_get( esc_url_raw( $query_url ) );
+
+		if (
+			is_wp_error( $data )
+			|| 200 !== $data['response']['code']
+			|| empty( $data['body'] )
+		) {
+			return $response_body;
+		}
+
+		$response_body = json_decode( $data['body'] );
+		return $response_body;
+	}
+
+	/**
+	 * Remote call to get information about a specific GitHub user.
+	 *
+	 * @since 1.6.0
+	 *
+	 * @param string $gh_username GitHub username.
+	 *
+	 * @return array $gh_user_details Details about a GitHub user.
+	 */
+	public function get_person_details( $gh_username = '' ) {
+		$gh_user_details = array();
+
+		if ( empty( $gh_username ) ) {
+			return $gh_user_details;
+		}
+
+		// Let's get some info from GitHub.
+		$query_url = sprintf(
+			'https://api.github.com/users/%1$s?access_token=%2$s',
+			$gh_username,
+			$this->get_option( 'access_token' )
+		);
+
+		$data = wp_remote_get( esc_url_raw( $query_url ) );
+
+		if (
+			is_wp_error( $data )
+			|| 200 !== $data['response']['code']
+			|| empty( $data['body'] )
+		) {
+			return $gh_user_details;
+		}
+
+		$person_info_body = json_decode( $data['body'] );
+
+		/**
+		 * Let's build a name based on the name field.
+		 * If it is not defined, fall back to username.
+		 */
+		if ( ! empty( $person_info_body->name ) ) {
+			$nicename = $person_info_body->name;
+		} else {
+			$nicename = $person_info_body->login;
+		}
+
+		// Build the array of data we will save.
+		$gh_user_details = array(
+			'name'       => esc_html( $nicename ),
+			'avatar_url' => esc_url( $person_info_body->avatar_url ),
+			'bio'        => esc_html( $person_info_body->bio ),
+		);
+
+		return $gh_user_details;
+	}
+
+	/**
+	 * Remote call to get label events for every monitored repo
+	 *
+	 * @since 2.1.0
+	 *
+	 * @return null|array
+	 */
+	public function get_github_issue_events() {
+		$response_body = array();
+
+		$repos_to_monitor = $this->get_monitored_repos( 'names' );
+		if ( empty( $repos_to_monitor ) ) {
+			return response_body;
+		}
+
+		foreach ( $repos_to_monitor as $repo_name ) {
+			$query_url = sprintf(
+				'https://api.github.com/repos/%1$s/issues/events?access_token=%2$s&per_page=100',
+				esc_html( $repo_name ),
+				$this->get_option( 'access_token' )
+			);
+
+			$data = wp_remote_get( esc_url_raw( $query_url ) );
+
+			if (
+				is_wp_error( $data )
+				|| 200 !== $data['response']['code']
+				|| empty( $data['body'] )
+			) {
+				return $response_body;
+			}
+
+			$single_response_body = json_decode( $data['body'] );
+			$response_body        = array_merge( $single_response_body, $response_body );
+		}
+
+		return $response_body;
+	}
+}

--- a/ghapi.ghactivity.php
+++ b/ghapi.ghactivity.php
@@ -236,7 +236,7 @@ class API_Calls {
 
 		$repos_to_monitor = $this->get_monitored_repos( 'names' );
 		if ( empty( $repos_to_monitor ) ) {
-			return response_body;
+			return $response_body;
 		}
 
 		foreach ( $repos_to_monitor as $repo_name ) {


### PR DESCRIPTION
This PR adds underlying functionality for https://github.com/Automattic/ghactivity/issues/3

It adds a possibility to record any label-related actions into label taxonomy.

#### Context:
There is a cron job which is fetching `repo` & `user` events (like PR/issue open/closed, comment added, commits added etc) and create relevant `GitHub Event` custom post type. In case of Issue/PR event - it also creates `GitHub Issue` CPT, where a bunch of different data (together with a list of labels) is stored as taxonomies.
The problem is that used API endpoints return only a limited range of Issue/PR event types (only `created` & `closed`), which means it not possible to track any label changes.

There is `/repos/repo_name/issues/events` endpoint which returns all the issue related events, but its schema differs from the endpoints mentioned above.

#### How things work:
Every time when cron job is triggered - this plugin will fetch `/repos/repo_name/issues/events` to get all the issue/PR related events (after other events were processed). For every `labeled` or `unlabeled` event it updates `Issue Event` label taxonomy (`ghactivity_issues_labels`) by adding term metadata such as: `status`, `labeled`, `unlabeled`. Label taxonomies are not unique, so to be able to distinguish one issue labels metadata from another I come up with this structure:

```
$slug = $repo_name . '#' . $issue_number; // e.g. automattic/ghactivity#13
$record = [
     "status" => [
       "labeled",
     ],
     "labeled" => [
       "2018-07-19T11:28:50Z",
     ],
     "unlabeled" => [
       "2018-07-19T10:10:44Z",
     ],
   ];

update_term_meta( $term_id, $slug, $record );
```
So now, any label which is used in multiple issues/repos will have metadata for every specific issue

Also, this PR includes some refactoring and nesting simplifications. 

#### To test:

- Login into test site: https://brbrr.wpsandbox.me/wp-admin
- Check list of the `Issue Events` here: https://brbrr.wpsandbox.me/wp-admin/edit.php?post_type=ghactivity_issue
- Create dummy issue in jetpack / ghactivity(preffered) / [brbrr/message_app](https://github.com/brbrr/message_app)
- Trigger `ghactivity_publish` cron job [here](https://brbrr.wpsandbox.me/wp-admin/tools.php?page=crontrol_admin_manage_page)
- Confirm that `Issue Events` now includes your new created issue. Figure out post_id of your issue (follow/hover post name to see url, it will include a post_id: http://cld.wthms.co/i5XoU7)
- Add a label to your issue.
- In SQL Executioner ([#](https://brbrr.wpsandbox.me/wp-admin/tools.php?page=sql-executioner)) run this query:
```sql
select tt.term_id, t.name, t.slug, tm.meta_key, tm.meta_value from $term_relationships as tr
inner join $term_taxonomy as tt on tr.term_taxonomy_id = tt.term_taxonomy_id
inner join $terms as t on tt.term_id=t.term_id
inner join $termmeta as tm on tm.term_id=t.term_id
where tr.object_id=YOUR_POST_ID
and tt.taxonomy='ghactivity_issues_labels'
```
- Update labels (add new/remove old) in your issue. re-trigger cron job, re-run SQL query. results should reflect changes you made. 

cron job may take 1-2 min to finish.  