### PR TITLE
Track label events in label taxonomy meta clean take

### DIFF
--- a/core.ghactivity.php
+++ b/core.ghactivity.php
@@ -401,7 +401,6 @@ class GHActivity_Calls {
 	 * @since 1.0
 	 */
 	public function publish_event() {
-		error_log( print_r( 'publish_event START!', 1 ) );
 		$github_events = $this->get_github_activity();
 
 		/**
@@ -585,7 +584,6 @@ class GHActivity_Calls {
 			}
 
 			$this->update_issue_labels();
-			error_log( print_r( 'publish_event DONE!', 1 ) );
 		}
 	}
 
@@ -1050,10 +1048,17 @@ class GHActivity_Calls {
 			return;
 		}
 
-		// Sorts all the events by created date from older to newer.
-		usort($event_list, function( $a, $b ) {
+		/**
+		 * Sort events by its creation date in ascending order
+		 *
+		 * @param Object $a Event object as it returned from Github API.
+		 * @param Object $b Event object as it returned from Github API.
+		 */
+		function sort_by_date( $a, $b ) {
 			return ( strtotime( $a->created_at ) < strtotime( $b->created_at ) ) ? -1 : 1;
-		} );
+		}
+		// Sorts all the events by created date from older to newer.
+		usort( $event_list, sort_by_date );
 
 		foreach ( $event_list as $event ) {
 			// process only labeled & unlabeled event types.
@@ -1069,7 +1074,6 @@ class GHActivity_Calls {
 			if ( ! $post_id ) {
 				continue;
 			}
-			error_log( print_r( $slug, 1 ) );
 			// Add missing labels if needed.
 			wp_set_object_terms( $post_id, $event->label->name, 'ghactivity_issues_labels', true );
 			$terms = wp_get_post_terms( $post_id, 'ghactivity_issues_labels' );
@@ -1086,11 +1090,11 @@ class GHActivity_Calls {
 			 */
 			foreach ( $terms as $term ) {
 				if ( $term->name === $event->label->name ) {
-					$record = [
+					$record = array(
 						'status'    => null,
 						'labeled'   => null,
 						'unlabeled' => null,
-					];
+					);
 					if ( metadata_exists( 'term', $term->term_id, $slug ) ) {
 						$record = get_term_meta( $term->term_id, $slug, true );
 					}


### PR DESCRIPTION
This PR adds underlying functionality for https://github.com/Automattic/ghactivity/issues/3

It adds a possibility to record any label-related actions into label taxonomy.

#### Context:
There is a cron job which is fetching `repo` & `user` events (like PR/issue open/closed, comment added, commits added etc) and create relevant `GitHub Event` custom post type. In case of Issue/PR event - it also creates `GitHub Issue` CPT, where a bunch of different data (together with a list of labels) is stored as taxonomies.
The problem is that used API endpoints return only a limited range of Issue/PR event types (only `created` & `closed`), which means it not possible to track any label changes.

There is `/repos/repo_name/issues/events` endpoint which returns all the issue related events, but its schema differs from the endpoints mentioned above.

#### How things work:
Every time when cron job is triggered - this plugin will fetch `/repos/repo_name/issues/events` to get all the issue/PR related events (after other events were processed). For every `labeled` or `unlabeled` event it updates `Issue Event` label taxonomy (`ghactivity_issues_labels`) by adding term metadata such as: `status`, `labeled`, `unlabeled`. Label taxonomies are not unique, so to be able to distinguish one issue labels metadata from another I come up with this structure:

```
$slug = $repo_name . '#' . $issue_number; // e.g. automattic/ghactivity#13
$record = [
     "status" => [
       "labeled",
     ],
     "labeled" => [
       "2018-07-19T11:28:50Z",
     ],
     "unlabeled" => [
       "2018-07-19T10:10:44Z",
     ],
   ];

update_term_meta( $term_id, $slug, $record );
```
So now, any label which is used in multiple issues/repos will have metadata for every specific issue

Also, this PR includes some refactoring and nesting simplifications. 

#### To test:

- Login into test site: https://brbrr.wpsandbox.me/wp-admin
- Check list of the `Issue Events` here: https://brbrr.wpsandbox.me/wp-admin/edit.php?post_type=ghactivity_issue
- Create dummy issue in jetpack / ghactivity(preffered) / [brbrr/message_app](https://github.com/brbrr/message_app)
- Trigger `ghactivity_publish` cron job [here](https://brbrr.wpsandbox.me/wp-admin/tools.php?page=crontrol_admin_manage_page)
- Confirm that `Issue Events` now includes your new created issue. Figure out post_id of your issue (follow/hover post name to see url, it will include a post_id: http://cld.wthms.co/i5XoU7)
- Add a label to your issue.
- In SQL Executioner ([#](https://brbrr.wpsandbox.me/wp-admin/tools.php?page=sql-executioner)) run this query.
```sql
select tt.term_id, t.name, t.slug, tm.meta_key, tm.meta_value from $term_relationships as tr
inner join $term_taxonomy as tt on tr.term_taxonomy_id = tt.term_taxonomy_id
inner join $terms as t on tt.term_id=t.term_id
inner join $termmeta as tm on tm.term_id=t.term_id
where tr.object_id=YOUR_POST_ID
and tt.taxonomy='ghactivity_issues_labels'
```
- Update labels (add new/remove old) in your issue. re-trigger cron job, re-run SQL query. results should reflect changes you made. 

cron job may take 1-2 min to finish.  