### PR TITLE
Teams: allow people to be a member of multiple teams

### DIFF
--- a/shortcodes/team-activity.php
+++ b/shortcodes/team-activity.php
@@ -21,12 +21,12 @@ function ghactivity_team_shortcode( $atts ) {
 	$team_members_args = array(
 		'taxonomy'   => 'ghactivity_actor',
 		'hide_empty' => false,
-		'fields'     => 'id=>slug',
+		'fields'     => 'id=>name',
 		'meta_query' => array(
 			array(
 				'key'     => 'team',
 				'value'   => esc_attr( $atts['team'] ),
-				'compare' => '=',
+				'compare' => 'LIKE',
 			),
 		),
 	);


### PR DESCRIPTION
Fixes #7 

- Now its possible to assign a person to multiple teams
- Make sure that code is backward compatible, and will work with the previous format (string > array)
- Fixed WP_Query issue in team-activity shortcode introduced in #4

To test:
- run it somewhere ;)
- under "/wp-admin/edit-tags.php?taxonomy=ghactivity_actor&post_type=ghactivity_event" select a Person and try to update their list of team