### PR TITLE
Include issue numbers in average_label_time shortcode

### DIFF
--- a/queries.ghactivity.php
+++ b/queries.ghactivity.php
@@ -144,7 +144,7 @@ class GHActivity_Queries {
 		$posts = get_posts( $args );
 
 		function get_post_content( $post ) {
-			return array( (int) $post->post_content, strtotime( $post->post_date ) );
+			return array( (int) $post->post_content, strtotime( $post->post_date ), get_post_meta( 2900, 'record_slugs', true ) );
 		}
 		return array_map( 'get_post_content', $posts );
 	}

--- a/queries.ghactivity.php
+++ b/queries.ghactivity.php
@@ -144,7 +144,11 @@ class GHActivity_Queries {
 		$posts = get_posts( $args );
 
 		function get_post_content( $post ) {
-			return array( (int) $post->post_content, strtotime( $post->post_date ), get_post_meta( 2900, 'record_slugs', true ) );
+			return array(
+				(int) $post->post_content,
+				strtotime( $post->post_date ),
+				get_post_meta( $post->ID, 'record_slugs', true ),
+			);
 		}
 		return array_map( 'get_post_content', $posts );
 	}

--- a/queries.ghactivity.php
+++ b/queries.ghactivity.php
@@ -30,8 +30,9 @@ class GHActivity_Queries {
 
 				// We want to capture only opened, labeled issues.
 				if ( $post_id && 'labeled' === $label_ary['status'] ) {
-					$dates[] = time() - strtotime( $label_ary['labeled'] );
-					$slugs[] = $repo_slug;
+					$time                = time() - strtotime( $label_ary['labeled'] );
+					$dates[]             = $time;
+					$slugs[ $repo_slug ] = $time;
 				}
 			}
 		}

--- a/rest.ghactivity.php
+++ b/rest.ghactivity.php
@@ -235,6 +235,7 @@ class Ghactivity_Api {
 			);
 		}
 
+		// [average_time, date_or_record, recorded_issues]
 		$records = GHActivity_Queries::fetch_average_label_time( $repo, $label );
 
 		$response = array(

--- a/shortcodes/js/components/AverageLabelTime.js
+++ b/shortcodes/js/components/AverageLabelTime.js
@@ -54,12 +54,15 @@ class AverageLabelTime extends Component {
 			)
 		}
 
-		records[ records.length - 1	][2].forEach(issueSlug => {
+		const issueSlugs = Object.entries(records[ records.length - 1	][2]);
+		issueSlugs.sort( (a, b) => b[1] - a[1] ) // Sort from older to newer
+		issueSlugs.forEach( ( [issueSlug, time], id  ) => {
 			const [ repoName, issueNumber ] = issueSlug.split('#')
 			const href = `https://github.com/${repoName}/pull/${issueNumber}`
+			const timeString = Math.round(time / 60 / 60 / 24) + ' days'
 			issues.push(
-				<li>
-					<a href={href} >#{issueNumber}</a>
+				<li key={id} >
+					<a href={href} >#{issueNumber}</a>  <span>{timeString}</span>
 				</li>
 			)
 		});

--- a/shortcodes/js/components/AverageLabelTime.js
+++ b/shortcodes/js/components/AverageLabelTime.js
@@ -44,7 +44,25 @@ class AverageLabelTime extends Component {
 		const { records } = this.state;
 		const labels = [];
 		const data = [];
+		const issues = [];
 
+		if ( !records || records.length === 0 ) {
+			return (
+				<div>
+					Loading...
+				</div>
+			)
+		}
+
+		records[ records.length - 1	][2].forEach(issueSlug => {
+			const [ repoName, issueNumber ] = issueSlug.split('#')
+			const href = `https://github.com/${repoName}/pull/${issueNumber}`
+			issues.push(
+				<li>
+					<a href={href} >#{issueNumber}</a>
+				</li>
+			)
+		});
 		records.forEach( r => {
 			data.push( r[ 0 ] / 60 / 60 / 24 ); // Convert seconds into days
 			labels.push( new Date( r[ 1 ] * 1000 ).toDateString() );
@@ -78,7 +96,11 @@ class AverageLabelTime extends Component {
 		return (
 			<div>
 				<Line data={ chartArgs } />
+				<ul>
+					{issues}
+				</ul>
 			</div>
+
 		);
 	}
 }


### PR DESCRIPTION
Fixes #18 

Adds a simple list of issues beneath the chart.  That list includes all the matching issues from latest schedule job (~1 day)

To test:
- open Any page with `average_label_time` shortcode [#](http://jeherve.wpsandbox.me/github-charts/average-time-of-prs-being-labeled-with-needs-review-label/) and see a list of clickable issues