### PR TITLE
Allow multiple labels in average_label_time shortcode

### DIFF
--- a/rest.ghactivity.php
+++ b/rest.ghactivity.php
@@ -332,7 +332,7 @@ class Ghactivity_Api {
 	public function get_average_label_time( $request ) {
 		if ( isset( $request['repo'] ) && isset( $request->get_query_params()['label'] ) ) {
 			$repo  = esc_html( $request['repo'] );
-			$label = esc_html( $request->get_query_params()['label'] );
+			$label = explode( ',', esc_html( $request->get_query_params()['label'] ) );
 		} else {
 			return new WP_Error(
 				'not_found',

--- a/schedule.ghactivity.php
+++ b/schedule.ghactivity.php
@@ -19,25 +19,25 @@ class GHActivity_Schedule {
 			)
 		);
 		foreach ( $label_slugs as $term ) {
-			$term_slug = explode( '#', $term->name );
-
-			$this->record_average_label_time( $term_slug[0], $term_slug[1] );
+			$term_name = explode( '#', $term->name );
+			$labels = explode( ',', $term_name[1] );
+			$this->record_average_label_time( $term_name[0], $labels );
 		}
 	}
 
-	public function record_average_label_time( $repo_name, $label ) {
-		$record          = GHActivity_Queries::current_average_label_time( $repo_name, $label );
+	public function record_average_label_time( $repo_name, $labels ) {
+		$record          = GHActivity_Queries::current_average_label_time( $repo_name, $labels );
 		$record_avg_time = $record[0];
 		$record_slugs    = $record[1];
 
 		$taxonomies = array(
 			'ghactivity_query_record_type' => 'average_label_time',
 			'ghactivity_repo'              => $repo_name,
-			'ghactivity_query_label_slug'  => $repo_name . '#' . $label,
+			'ghactivity_query_label_slug'  => $repo_name . '#' . implode( ',', $labels ),
 		);
 
 		$event_args = array(
-			'post_title'   => $repo_name . ' | ' . $label . ' | ' . date( DATE_RSS ),
+			'post_title'   => $repo_name . ' | ' . implode( ',', $labels ) . ' | ' . date( DATE_RSS ),
 			'post_type'    => 'gh_query_record',
 			'post_status'  => 'publish',
 			'tax_input'    => $taxonomies,


### PR DESCRIPTION
Adds ability to parse & collect records for label arrays, read them from shortcode, fetch them from db.

To test:
- Create new such Query Label Slug with name as `automattic/jetpack#[Status] Needs Review,[Type] Enhancement`
- Add a new page with shortcode: `[ghactivity_average_label_time repo="automattic/jetpack" label="[Status] Needs Review,[Type] Enhancement"]`
- trigger `gh_query_average_label_time` cron task to create initial data