### PR TITLE
Add new parameter to the `ghactivity_average_label_time` Shortcode

### DIFF
--- a/shortcodes/average-label-time.php
+++ b/shortcodes/average-label-time.php
@@ -25,6 +25,7 @@ function output_average_label_time( $atts ) {
 	$atts = shortcode_atts( array(
 		'repo'  => '',
 		'label' => '',
+		'num_only' => false,
 	), $atts, 'ghactivity_average_label_time' );
 
 	/**
@@ -42,6 +43,7 @@ function output_average_label_time( $atts ) {
 		'api_nonce' => wp_create_nonce( 'wp_rest' ),
 		'repo'      => esc_attr( $atts['repo'] ),
 		'label'     => esc_attr( $atts['label'] ),
+		'numOnly'   => esc_attr( $atts['num_only'] ),
 	);
 	wp_localize_script( 'ghactivity-average-label-time', 'ghactivity_avg_label_time', $args );
 	wp_enqueue_script( 'ghactivity-average-label-time' );

--- a/shortcodes/js/average-label-time.js
+++ b/shortcodes/js/average-label-time.js
@@ -8,12 +8,13 @@ import { render } from 'react-dom';
  * Internal dependencies
  */
 import AverageLabelTime from './components/AverageLabelTime';
-const { repo, label } = ghactivity_avg_label_time;
+const { repo, label, numOnly } = ghactivity_avg_label_time;
 const className = `${repo}#${label}`.toLowerCase().replace(/\W/gi,'-');
 
 render((
 	<AverageLabelTime
 		repo={ repo }
 		label={ label }
+		numOnly={ numOnly }
 	/>
 ), document.querySelector( `#avg-label-time.${className}` ) );

--- a/shortcodes/js/components/AverageLabelTime.js
+++ b/shortcodes/js/components/AverageLabelTime.js
@@ -41,6 +41,7 @@ class AverageLabelTime extends Component {
 
 	render() {
 		const { records } = this.state;
+		const { numOnly } = this.props;
 		const labels = [];
 		const avgTimeData = [];
 		const issuesNumData = [];
@@ -71,6 +72,20 @@ class AverageLabelTime extends Component {
 			labels.push( new Date( recordDate * 1000 ).toDateString() );
 			issuesNumData.push( Object.values( recordedIssues ).length );
 		} );
+
+		// Will not display a chart.
+		if ( numOnly ) {
+			const currentAvgTimeIndex = avgTimeData.length -1,
+				currentAvgTime = avgTimeData[ currentAvgTimeIndex ];
+
+			return(
+				<div className="average-time-number-only">
+					<h2>{currentAvgTime} Days.</h2>
+					{issues}
+				</div>
+			);
+		}
+
 		const chartArgs = {
 			labels,
 			datasets: [


### PR DESCRIPTION
Will not output a chart, but instead just the number of the average time, like so: 

![screen shot 2018-12-19 at 1 50 54 pm](https://user-images.githubusercontent.com/7129409/50241395-67eb6000-0395-11e9-9364-25935bce6b61.png)

To Test: Add this to a Page
`[ghactivity_average_label_time repo="Automattic/jpop-issues" label="&#91;Status&#93; Needs Dash" num_only=1]`