### PR TITLE
Refactor ghactivity_average_label_time shortcode to only allow ID parameter.

### DIFF
--- a/queries.ghactivity.php
+++ b/queries.ghactivity.php
@@ -438,8 +438,8 @@ class GHActivity_Queries {
 		return $post_id;
 	}
 
-	public static function fetch_average_label_time( $repo_name, $label, $range = null ) {
-		$slug = $repo_name . '#' . implode( ',', $label );
+	public static function fetch_average_label_time( $repo_name, $label, $id, $range = null ) {
+		$term = ! empty( $id ) ? $id : $repo_name . '#' . implode( ',', $label );
 		$args = array(
 			'post_type'      => 'gh_query_record',
 			'post_status'    => 'publish',
@@ -449,8 +449,8 @@ class GHActivity_Queries {
 			'tax_query'      => array(
 				array(
 					'taxonomy' => 'ghactivity_query_label_slug',
-					'field'    => 'name',
-					'terms'    => $slug,
+					'field'    => ! empty( $id ) ? 'id' : 'name',
+					'terms'    => $term,
 				),
 			),
 		);

--- a/queries.ghactivity.php
+++ b/queries.ghactivity.php
@@ -438,8 +438,7 @@ class GHActivity_Queries {
 		return $post_id;
 	}
 
-	public static function fetch_average_label_time( $repo_name, $label, $id, $range = null ) {
-		$term = ! empty( $id ) ? $id : $repo_name . '#' . implode( ',', $label );
+	public static function fetch_average_label_time( $id, $range = null ) {
 		$args = array(
 			'post_type'      => 'gh_query_record',
 			'post_status'    => 'publish',
@@ -449,8 +448,8 @@ class GHActivity_Queries {
 			'tax_query'      => array(
 				array(
 					'taxonomy' => 'ghactivity_query_label_slug',
-					'field'    => ! empty( $id ) ? 'id' : 'name',
-					'terms'    => $term,
+					'field'    => 'id',
+					'terms'    => $id,
 				),
 			),
 		);

--- a/rest.ghactivity.php
+++ b/rest.ghactivity.php
@@ -350,6 +350,7 @@ class Ghactivity_Api {
 		if ( isset( $request['repo'] ) && isset( $request->get_query_params()['label'] ) ) {
 			$repo  = esc_html( $request['repo'] );
 			$label = explode( ',', esc_html( $request->get_query_params()['label'] ) );
+			$id    = esc_html( $request->get_query_params()['id'] );
 		} else {
 			return new WP_Error(
 				'not_found',
@@ -361,11 +362,12 @@ class Ghactivity_Api {
 		}
 
 		// [average_time, date_of_record, recorded_issues]
-		$records = GHActivity_Queries::fetch_average_label_time( $repo, $label );
+		$records = GHActivity_Queries::fetch_average_label_time( $repo, $label, $id, null );
 
 		$response = array(
 			'repo'    => $repo,
 			'label'   => $label,
+			'id'      => $id,
 			'records' => $records,
 		);
 		return new WP_REST_Response( $response, 200 );

--- a/rest.ghactivity.php
+++ b/rest.ghactivity.php
@@ -347,14 +347,14 @@ class Ghactivity_Api {
 	 * @return WP_REST_Response $response Stats for a specific repo.
 	 */
 	public function get_average_label_time( $request ) {
-		if ( isset( $request['repo'] ) && isset( $request->get_query_params()['label'] ) ) {
+		if ( ! empty( $request['id'] ) || ( ! empty( $request['repo'] ) && ! empty( $request->get_query_params()['label'] ) ) ) {
 			$repo  = esc_html( $request['repo'] );
 			$label = explode( ',', esc_html( $request->get_query_params()['label'] ) );
 			$id    = esc_html( $request->get_query_params()['id'] );
 		} else {
 			return new WP_Error(
 				'not_found',
-				esc_html__( 'You did not specify a valid GitHub repo and/or issue label', 'ghactivity' ),
+				esc_html__( 'You did not specify a valid GitHub repo and/or issue label and/or ID', 'ghactivity' ),
 				array(
 					'status' => 404,
 				)

--- a/rest.ghactivity.php
+++ b/rest.ghactivity.php
@@ -67,14 +67,13 @@ class Ghactivity_Api {
 		 *
 		 * @since 2.1.0
 		 */
-		register_rest_route( 'ghactivity/v1', '/queries/average-label-time/repo/(?P<repo>[0-9a-z\-_\/]+)', array(
+		register_rest_route( 'ghactivity/v1', '/queries/average-label-time', array(
 			'methods'             => WP_REST_Server::READABLE,
 			'callback'            => array( $this, 'get_average_label_time' ),
 			'permission_callback' => array( $this, 'permissions_check' ),
 			'args'                => array(
-				'repo' => array(
-					'required'          => true,
-					'validate_callback' => array( $this, 'validate_string' ),
+				'id' => array(
+					'required' => true,
 				),
 			),
 		) );
@@ -347,14 +346,12 @@ class Ghactivity_Api {
 	 * @return WP_REST_Response $response Stats for a specific repo.
 	 */
 	public function get_average_label_time( $request ) {
-		if ( ! empty( $request['id'] ) || ( ! empty( $request['repo'] ) && ! empty( $request->get_query_params()['label'] ) ) ) {
-			$repo  = esc_html( $request['repo'] );
-			$label = explode( ',', esc_html( $request->get_query_params()['label'] ) );
-			$id    = esc_html( $request->get_query_params()['id'] );
+		if ( ! empty( $request['id'] ) ) {
+			$id = esc_html( $request['id'] );
 		} else {
 			return new WP_Error(
 				'not_found',
-				esc_html__( 'You did not specify a valid GitHub repo and/or issue label and/or ID', 'ghactivity' ),
+				esc_html__( 'You did not specify a ID for the term you want to query.', 'ghactivity' ),
 				array(
 					'status' => 404,
 				)
@@ -362,11 +359,9 @@ class Ghactivity_Api {
 		}
 
 		// [average_time, date_of_record, recorded_issues]
-		$records = GHActivity_Queries::fetch_average_label_time( $repo, $label, $id, null );
+		$records = GHActivity_Queries::fetch_average_label_time( $id, null );
 
 		$response = array(
-			'repo'    => $repo,
-			'label'   => $label,
 			'id'      => $id,
 			'records' => $records,
 		);

--- a/shortcodes/average-label-time.php
+++ b/shortcodes/average-label-time.php
@@ -48,6 +48,6 @@ function output_average_label_time( $atts ) {
 	wp_localize_script( 'ghactivity-average-label-time', 'ghactivity_avg_label_time', $args );
 	wp_enqueue_script( 'ghactivity-average-label-time' );
 
-	$class_name = preg_replace( '/\W/', '-', strtolower( html_entity_decode( $args['repo'] ) . '#' . html_entity_decode( $args['label'] ) ) );
+	$class_name = preg_replace( '/\W/', '-', strtolower( html_entity_decode( $args['repo'] ) . '#' . html_entity_decode( $args['label'] ) . html_entity_decode( $args['id'] ) ) );
 	return "<div id='avg-label-time' class='" . $class_name . "'></div>";
 }

--- a/shortcodes/average-label-time.php
+++ b/shortcodes/average-label-time.php
@@ -23,8 +23,6 @@ add_shortcode( 'ghactivity_average_label_time', 'output_average_label_time' );
  */
 function output_average_label_time( $atts ) {
 	$atts = shortcode_atts( array(
-		'repo'  => '',
-		'label' => '',
 		'id'    => '',
 	), $atts, 'ghactivity_average_label_time' );
 
@@ -41,13 +39,11 @@ function output_average_label_time( $atts ) {
 		'api_url'   => esc_url_raw( rest_url() ),
 		'site_url'  => esc_url_raw( home_url() ),
 		'api_nonce' => wp_create_nonce( 'wp_rest' ),
-		'repo'      => esc_attr( $atts['repo'] ),
-		'label'     => esc_attr( $atts['label'] ),
 		'id'        => esc_attr( $atts['id'] ),
 	);
 	wp_localize_script( 'ghactivity-average-label-time', 'ghactivity_avg_label_time', $args );
 	wp_enqueue_script( 'ghactivity-average-label-time' );
 
-	$class_name = preg_replace( '/\W/', '-', strtolower( html_entity_decode( $args['repo'] ) . '#' . html_entity_decode( $args['label'] ) . html_entity_decode( $args['id'] ) ) );
+	$class_name = "avg-label-time-".html_entity_decode( $args['id'] );
 	return "<div id='avg-label-time' class='" . $class_name . "'></div>";
 }

--- a/shortcodes/average-label-time.php
+++ b/shortcodes/average-label-time.php
@@ -25,6 +25,7 @@ function output_average_label_time( $atts ) {
 	$atts = shortcode_atts( array(
 		'repo'  => '',
 		'label' => '',
+		'id'    => '',
 	), $atts, 'ghactivity_average_label_time' );
 
 	/**
@@ -42,6 +43,7 @@ function output_average_label_time( $atts ) {
 		'api_nonce' => wp_create_nonce( 'wp_rest' ),
 		'repo'      => esc_attr( $atts['repo'] ),
 		'label'     => esc_attr( $atts['label'] ),
+		'id'        => esc_attr( $atts['id'] ),
 	);
 	wp_localize_script( 'ghactivity-average-label-time', 'ghactivity_avg_label_time', $args );
 	wp_enqueue_script( 'ghactivity-average-label-time' );

--- a/shortcodes/js/average-label-time.js
+++ b/shortcodes/js/average-label-time.js
@@ -9,7 +9,7 @@ import { render } from 'react-dom';
  */
 import AverageLabelTime from './components/AverageLabelTime';
 const { repo, label, id } = ghactivity_avg_label_time;
-const className = `${repo}#${label}`.toLowerCase().replace(/\W/gi,'-');
+const className = `${repo}#${label}${id}`.toLowerCase().replace(/\W/gi,'-');
 
 render((
 	<AverageLabelTime

--- a/shortcodes/js/average-label-time.js
+++ b/shortcodes/js/average-label-time.js
@@ -8,13 +8,11 @@ import { render } from 'react-dom';
  * Internal dependencies
  */
 import AverageLabelTime from './components/AverageLabelTime';
-const { repo, label, id } = ghactivity_avg_label_time;
-const className = `${repo}#${label}${id}`.toLowerCase().replace(/\W/gi,'-');
+const { id } = ghactivity_avg_label_time;
+const className = `avg-label-time-${id}`;
 
 render((
 	<AverageLabelTime
-		repo={ repo }
-		label={ label }
 		id={ id }
 	/>
 ), document.querySelector( `#avg-label-time.${className}` ) );

--- a/shortcodes/js/average-label-time.js
+++ b/shortcodes/js/average-label-time.js
@@ -8,12 +8,13 @@ import { render } from 'react-dom';
  * Internal dependencies
  */
 import AverageLabelTime from './components/AverageLabelTime';
-const { repo, label } = ghactivity_avg_label_time;
+const { repo, label, id } = ghactivity_avg_label_time;
 const className = `${repo}#${label}`.toLowerCase().replace(/\W/gi,'-');
 
 render((
 	<AverageLabelTime
 		repo={ repo }
 		label={ label }
+		id={ id }
 	/>
 ), document.querySelector( `#avg-label-time.${className}` ) );

--- a/shortcodes/js/components/AverageLabelTime.js
+++ b/shortcodes/js/components/AverageLabelTime.js
@@ -18,10 +18,10 @@ class AverageLabelTime extends Component {
 	}
 
 	fetchActivity() {
-		const { repo, label, id } = this.props;
+		const { id } = this.props;
 		const { api_url, api_nonce } = ghactivity_avg_label_time;
 		return fetch(
-			`${ api_url }ghactivity/v1/queries/average-label-time/repo/${ repo }/?label=${ encodeURI( label ) }&id=${ encodeURI( id ) }`,
+			`${ api_url }ghactivity/v1/queries/average-label-time/?id=${ encodeURI( id ) }`,
 			{
 				credentials: 'same-origin',
 				headers: {
@@ -148,8 +148,7 @@ class AverageLabelTime extends Component {
 }
 
 AverageLabelTime.propTypes = {
-	repo: PropTypes.string.isRequired,
-	label: PropTypes.string.isRequired,
+	id: PropTypes.string.isRequired,
 };
 
 export default AverageLabelTime;

--- a/shortcodes/js/components/AverageLabelTime.js
+++ b/shortcodes/js/components/AverageLabelTime.js
@@ -18,10 +18,10 @@ class AverageLabelTime extends Component {
 	}
 
 	fetchActivity() {
-		const { repo, label } = this.props;
+		const { repo, label, id } = this.props;
 		const { api_url, api_nonce } = ghactivity_avg_label_time;
 		return fetch(
-			`${ api_url }ghactivity/v1/queries/average-label-time/repo/${ repo }/?label=${ encodeURI( label ) }`,
+			`${ api_url }ghactivity/v1/queries/average-label-time/repo/${ repo }/?label=${ encodeURI( label ) }&id=${ encodeURI( id ) }`,
 			{
 				credentials: 'same-origin',
 				headers: {


### PR DESCRIPTION
Since this shortcode currently needs to query an existing `ghactivity_query_label_slug` taxonomy record, the `label` and `repo` usage throughout the API and in the shortcode attributes is not needed.

This PR greatly simplifies things by only accepting an `id` attribute to the shortcode. 

Like this: 
- `[ghactivity_average_label_time id="951"]`

To test: 
- Choose your favorite `ghactivity_query_label_slug` taxonomy from the `gh_query_record` post type.
- Find the ID of this taxonomy by looking at it's URL
- Add a shortcode like the one above. It should render the same as it did before. 