### PR TITLE
Fix/duplicated records bug

### DIFF
--- a/core.ghactivity.php
+++ b/core.ghactivity.php
@@ -466,7 +466,7 @@ class GHActivity_Calls {
 	private function record_issue_details( $issue_details ) {
 		$post_id = GHActivity_Queries::find_gh_issue( $issue_details['repo_name'], $issue_details['number'] );
 
-		if ( $post_id ) {
+		if ( ! $post_id ) {
 			// Create taxonomies.
 			$taxonomies = array(
 				'ghactivity_repo'          => $issue_details['repo_name'],

--- a/core.ghactivity.php
+++ b/core.ghactivity.php
@@ -599,8 +599,8 @@ class GHActivity_Calls {
 				$post_id      = $options['post_id'];
 			} else {
 				preg_match( '/(?<=repos\/)(.*?)(?=\/issues)/', $event->url, $match );
-				if ( ! isset(  $event->issue->number ) ) {
-				    continue;
+				if ( ! isset( $event->issue->number ) ) {
+					continue;
 				}
 				$issue_number = $event->issue->number;
 				$repo_name    = $match[0];
@@ -614,17 +614,22 @@ class GHActivity_Calls {
 
 			// If issue is closed/reopened - update ghactivity_issues_state accordingly, and continue to next event.
 			if ( 'closed' === $event->event ) {
+				error_log( '  -- Setting ghactivity_issues_state as closed' );
 				wp_set_post_terms( $post_id, 'closed', 'ghactivity_issues_state', false );
 				continue;
 			} elseif ( 'reopened' === $event->event ) {
+				error_log( '  -- Setting ghactivity_issues_state as open' );
 				wp_set_post_terms( $post_id, 'open', 'ghactivity_issues_state', false );
 				continue;
 			}
 
 			// Update label list according to event data.
-			if ( 'labeled' === $event->event ) { // Add missing labels if needed.
+			if ( 'labeled' === $event->event ) {
+				// Add missing labels if needed.
+				error_log( '  -- Labeled. Adding: ' . $event->label->name );
 				wp_set_post_terms( $post_id, $event->label->name, 'ghactivity_issues_labels', true );
 			} elseif ( 'unlabeled' === $event->event ) {
+				error_log( '  -- Unlabeled. Removing: ' . $event->label->name );
 				wp_remove_object_terms( $post_id, $event->label->name, 'ghactivity_issues_labels' );
 			}
 
@@ -658,6 +663,7 @@ class GHActivity_Calls {
 			}
 			$record['status']        = $event->event;
 			$record[ $event->event ] = $event->created_at;
+			error_log( '  -- Updating ghactivity_issues_labels tax.' );
 			update_term_meta( $term->term_id, $slug, $record );
 		}
 	}

--- a/github.ghactivity.php
+++ b/github.ghactivity.php
@@ -309,7 +309,7 @@ class GHActivity_GHApi {
 	 *
 	 * @return array $response_body Response body for each call.
 	 */
-	public function get_all_github_data( $query_url, $headers ) {
+	public function get_all_github_data( $query_url, $headers = array() ) {
 		$page        = 1;
 		$all_results = array();
 		// Fetch API until empty array will be returned.

--- a/github.ghactivity.php
+++ b/github.ghactivity.php
@@ -214,7 +214,7 @@ class GHActivity_GHApi {
 				esc_html( $issue_number ? '/' . $issue_number : '' ),
 				$this->token
 			);
-			$single_response_body = $this->get_github_data( $query_url );
+			$single_response_body = $this->get_all_github_data( $query_url );
 			$response_body        = array_merge( $single_response_body, $response_body );
 		}
 		return $response_body;

--- a/queries.ghactivity.php
+++ b/queries.ghactivity.php
@@ -584,4 +584,36 @@ class GHActivity_Queries {
 
 		return array( $minified_columns, $project->html_url );
 	}
+
+	/**
+	 * Returns array of post_ids of open issues for specified repo
+	 */
+	public static function get_all_open_gh_issues( $repo_name ) {
+		$is_open_args = array(
+			'post_type'      => 'ghactivity_issue',
+			'post_status'    => 'publish',
+			'fields'          => 'ids', // Only get post IDs
+			'posts_per_page' => -1,
+			'tax_query'      => array(
+				'relation' => 'AND',
+				array(
+					'taxonomy' => 'ghactivity_issues_state',
+					'field'    => 'name',
+					'terms'    => 'open',
+				),
+				array(
+					'taxonomy' => 'ghactivity_repo',
+					'field'    => 'name',
+					'terms'    => $repo_name,
+				),
+			),
+		);
+		$posts_ids = wp_cache_get( 'all_open_gh_issues_' . $repo_name );
+		if ( false === $posts_ids ) {
+			$posts_ids = get_posts( $is_open_args );
+			wp_reset_postdata();
+			wp_cache_set( 'all_open_gh_issues_' . $repo_name, $posts_ids, '', 30 * 60 /** 30 min */ );
+		}
+		return $posts_ids;
+	}
 }


### PR DESCRIPTION
This PR fixes the bug because of which multiple duplicated Issues CPT were created. This also adds `ghactivity/v1/remove-duplicated-issues` endpoint to trigger duplicate deletion task. This endpoint is a temporary measure, which will be removed after clean-up in other PR

Also, it updates `label_scan_action` to be more effective