### PR TITLE
Attempt to fix a AverageLabelTime issues

### DIFF
--- a/admin.ghactivity.php
+++ b/admin.ghactivity.php
@@ -472,7 +472,7 @@ function label_scan_action() {
 				'post_id'      => $post_id,
 			);
 			error_log( 'Rescanning ' . $repo . ' :: ' . $issue_number );
-			$gha->update_issue_records( $response, $options );
+			$gha->update_issue_records_meta( $response, $options );
 		}
 	}
 	error_log( 'Done with rescan!' );

--- a/admin.ghactivity.php
+++ b/admin.ghactivity.php
@@ -108,13 +108,6 @@ function ghactivity_options_init() {
 		'ghactivity'
 	);
 	add_settings_field(
-		'ghactivity_label_scan',
-		__( 'Initialize GitHub labels scan', 'ghactivity' ),
-		'ghactivity_label_scan_callback',
-		'ghactivity',
-		'ghactivity_restart_triggers'
-	);
-	add_settings_field(
 		'ghactivity_redo_graphs',
 		__( 'Re-build Graphs', 'ghactivity' ),
 		'ghactivity_redo_graphs_callback',
@@ -261,35 +254,43 @@ function ghactivity_sync_settings_full_sync_callback() {
 		},
 	$repos_to_monitor );
 
+	if ( empty( $repos_to_monitor ) ) {
+		return esc_html_e( 'You currently do not monitor activity on any repository. You cannot use this option yet.', 'ghactivity' );
+	}
+
 	// Gather info about our watched repos, and the current sync status.
-	if ( ! empty( $repos_to_monitor ) ) {
-		foreach ( $repos_to_monitor as $repo ) {
-			$sync_status = isset( $options[ $repo . '_full_sync' ] ) ? $options[ $repo . '_full_sync' ] : '';
-			if ( ! empty( $sync_status ) ) {
-				if ( 'done' === $sync_status['status'] ) {
-					printf(
-						__( 'All events for the %1$s repository have already been synchronized. Check them <a href="%2$s">here</a>.', 'ghactivity' ),
-						esc_html( $repo ),
-						esc_url( get_admin_url( null, 'edit.php?post_type=ghactivity_issue' ) )
-					);
-				} else {
-					printf(
-						__( 'Synchronization for the %1$s repository in progress. There are still %2$d pages to process.', 'ghactivity' ),
-						esc_html( $repo ),
-						absint( $sync_status['pages'] )
-					);
-				}
+	foreach ( $repos_to_monitor as $repo ) {
+		$sync_status = isset( $options[ $repo . '_full_sync' ] ) ? $options[ $repo . '_full_sync' ] : '';
+		printf( '<div><strong>%1$s</strong>: ', esc_attr( $repo ) );
+
+		if ( ! empty( $sync_status ) ) {
+			if ( 'done' === $sync_status['status'] ) {
+				printf(
+					__( 'All events for the %1$s repository have already been synchronized. Check them <a href="%2$s">here</a>.', 'ghactivity' ),
+					esc_html( $repo ),
+					esc_url( get_admin_url( null, 'edit.php?post_type=ghactivity_issue&ghactivity_repo=' . $repo ) )
+				);
 			} else {
 				// we push to start the sync here.
 				printf(
-					'<div><strong>%1$s</strong>: <input class="full_sync" id="%1$s_full_sync" type="button" name="%1$s_full_sync" value="%2$s" class="button button-secondary" /><p id="%1$s_full_sync_details" style="display:none;"></p></div>',
-					esc_attr( $repo ),
-					esc_html__( 'Start synchronizing all issues', 'ghactivity' )
+					__( 'Synchronization for the %1$s repository in progress. There are still %2$d pages to process.', 'ghactivity' ),
+					esc_html( $repo ),
+					absint( $sync_status['pages'] )
 				);
 			}
+			printf(
+				'<input class="reset_sync_status" id="%1$s_reset_sync_status" type="button" value="Reset sync status" class="button button-secondary" />',
+				esc_attr( $repo )
+			);
+		} else {
+			// we push to start the sync here.
+			printf(
+				'<input class="full_sync" id="%1$s_full_sync" type="button" name="%1$s_full_sync" value="%2$s" class="button button-secondary" /><p id="%1$s_full_sync_details" style="display:none;"></p>',
+				esc_attr( $repo ),
+				esc_html__( 'Start synchronizing all issues', 'ghactivity' )
+			);
 		}
-	} else {
-		esc_html_e( 'You currently do not monitor activity on any repository. You cannot use this option yet.', 'ghactivity' );
+		printf( '</div>' );
 	}
 }
 
@@ -405,77 +406,6 @@ function query_label_slug_action() {
 	check_ajax_referer( 'ghactivity-label-scan-nonce', 'security' );
 	wp_suspend_cache_addition( true );
 	do_action( 'gh_query_average_label_time' );
-	wp_die(); // this is required to terminate immediately and return a proper response.
-}
-
-
-
-/**
- * GitHub Label Scan section.
- *
- * @since 2.1.0
- */
-function ghactivity_label_scan_callback() {
-	echo '<p>';
-	esc_html_e( 'This button will scan for all the label updates for recorded issues' );
-	echo '</p>';
-
-	echo '<div class="wrap">';
-	echo '<button onclick="triggerLabelScan()" class="button button-secondary">';
-	esc_html_e( 'Trigger Label Rescan', 'ghactivity' );
-	echo '</button>';
-	echo '</div>';
-
-	$ajax_nonce      = wp_create_nonce( 'ghactivity-label-scan-nonce' );
-	$confirm_dialog  = esc_html__( 'This is time-consuming operation. Make sure not to run it more then once!', 'ghactivity' );
-	$response_dialog = esc_html__( 'Got this from the server: ', 'ghactivity' );
-	?>
-		<script type="text/javascript" >
-		function triggerLabelScan($) {
-			if ( ! confirm( '<?php echo esc_html( $confirm_dialog ); ?>' ) ) {
-				return;
-			}
-			var data = {
-				'action': 'label_scan_action',
-				'security': '<?php echo esc_html( $ajax_nonce ); ?>',
-			};
-
-			// since 2.8 ajaxurl is always defined in the admin header and points to admin-ajax.php
-			jQuery.post( ajaxurl, data, function( response ) {
-				alert( '<?php echo esc_html( $response_dialog ); ?>'  + response );
-			} );
-		}
-		</script>
-		<?php
-}
-
-add_action( 'wp_ajax_label_scan_action', 'label_scan_action' );
-
-/**
- * Goes through all the existing `ghactivity_issue` posts and update their labels & state
- */
-function label_scan_action() {
-	check_ajax_referer( 'ghactivity-label-scan-nonce', 'security' );
-	wp_suspend_cache_addition( true );
-	$gha   = new GHActivity_Calls();
-	$repos = GHActivity_Queries::get_monitored_repos( 'names' );
-
-	foreach ( $repos as $repo ) {
-		$post_ids = GHActivity_Queries::get_all_open_gh_issues( $repo );
-		foreach ( $post_ids as $post_id ) {
-			set_time_limit( 300 );
-			$issue_number = get_post_meta( $post_id, 'number', true );
-			$response     = $gha->api->get_github_issue_events( $repo, $issue_number );
-			$options      = array(
-				'issue_number' => $issue_number,
-				'repo_name'    => $repo,
-				'post_id'      => $post_id,
-			);
-			error_log( 'Rescanning ' . $repo . ' :: ' . $issue_number );
-			$gha->update_issue_records_meta( $response, $options );
-		}
-	}
-	error_log( 'Done with rescan!' );
 	wp_die(); // this is required to terminate immediately and return a proper response.
 }
 

--- a/composer.json
+++ b/composer.json
@@ -8,12 +8,13 @@
     "url": "https://github.com/automattic/ghactivity/issues"
   },
   "require"    : {
-      "composer/installers": "~1.0"
+    "composer/installers": "~1.0"
   },
   "require-dev": {
-      "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
-      "wp-coding-standards/wpcs": "^0.14.0",
-      "sirbrillig/phpcs-variable-analysis": "^2.0",
-      "wimg/php-compatibility": "^8.1"
+    "squizlabs/php_codesniffer": "^3.4",
+    "wp-coding-standards/wpcs": "^1.2",
+    "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
+    "sirbrillig/phpcs-variable-analysis": "^2.0",
+    "wimg/php-compatibility": "^8.1"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "bd909f46afb899166f9bf9ff7514edaa",
+    "content-hash": "d6b8f06addc12094112224cf71e2e371",
     "packages": [
         {
             "name": "composer/installers",
@@ -125,6 +125,100 @@
                 "zikula"
             ],
             "time": "2017-12-29T09:13:20+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "379deb987e26c7cd103a7b387aea178baec96e48"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/379deb987e26c7cd103a7b387aea178baec96e48",
+                "reference": "379deb987e26c7cd103a7b387aea178baec96e48",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "bin": [
+                "bin/phpcs",
+                "bin/phpcbf"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "http://www.squizlabs.com/php-codesniffer",
+            "keywords": [
+                "phpcs",
+                "standards"
+            ],
+            "time": "2018-12-19T23:57:18+00:00"
+        },
+        {
+            "name": "wp-coding-standards/wpcs",
+            "version": "1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git",
+                "reference": "f328bcafd97377e8e5e5d7b244d5ddbf301a3a5c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/WordPress-Coding-Standards/WordPress-Coding-Standards/zipball/f328bcafd97377e8e5e5d7b244d5ddbf301a3a5c",
+                "reference": "f328bcafd97377e8e5e5d7b244d5ddbf301a3a5c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.9.0 || ^3.0.2"
+            },
+            "require-dev": {
+                "phpcompatibility/php-compatibility": "^9.0"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer rules (sniffs) to enforce WordPress coding conventions",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "wordpress"
+            ],
+            "time": "2018-12-18T09:43:51+00:00"
         }
     ],
     "packages-dev": [
@@ -238,57 +332,6 @@
             "time": "2018-04-27T15:26:25+00:00"
         },
         {
-            "name": "squizlabs/php_codesniffer",
-            "version": "3.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "d86873af43b4aa9d1f39a3601cc0cfcf02b25266"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/d86873af43b4aa9d1f39a3601cc0cfcf02b25266",
-                "reference": "d86873af43b4aa9d1f39a3601cc0cfcf02b25266",
-                "shasum": ""
-            },
-            "require": {
-                "ext-simplexml": "*",
-                "ext-tokenizer": "*",
-                "ext-xmlwriter": "*",
-                "php": ">=5.4.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
-            },
-            "bin": [
-                "bin/phpcs",
-                "bin/phpcbf"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.x-dev"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Greg Sherwood",
-                    "role": "lead"
-                }
-            ],
-            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
-            "homepage": "http://www.squizlabs.com/php-codesniffer",
-            "keywords": [
-                "phpcs",
-                "standards"
-            ],
-            "time": "2018-06-06T23:58:19+00:00"
-        },
-        {
             "name": "wimg/php-compatibility",
             "version": "8.1.0",
             "source": {
@@ -339,46 +382,6 @@
                 "standards"
             ],
             "time": "2017-12-27T21:58:38+00:00"
-        },
-        {
-            "name": "wp-coding-standards/wpcs",
-            "version": "0.14.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git",
-                "reference": "cf6b310caad735816caef7573295f8a534374706"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/WordPress-Coding-Standards/WordPress-Coding-Standards/zipball/cf6b310caad735816caef7573295f8a534374706",
-                "reference": "cf6b310caad735816caef7573295f8a534374706",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3",
-                "squizlabs/php_codesniffer": "^2.9.0 || ^3.0.2"
-            },
-            "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3"
-            },
-            "type": "phpcodesniffer-standard",
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Contributors",
-                    "homepage": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/graphs/contributors"
-                }
-            ],
-            "description": "PHP_CodeSniffer rules (sniffs) to enforce WordPress coding conventions",
-            "keywords": [
-                "phpcs",
-                "standards",
-                "wordpress"
-            ],
-            "time": "2018-02-16T01:57:48+00:00"
         }
     ],
     "aliases": [],

--- a/core.ghactivity.php
+++ b/core.ghactivity.php
@@ -661,8 +661,12 @@ class GHActivity_Calls {
 	 *
 	 * @return bool $done Returns true when done.
 	 */
-	public function full_issue_sync( $repo_slug ) {
+	public function full_issue_sync( $repo_slug, $reset = false ) {
 		error_log( 'FULL ISSUE SYNC STARTED FOR' . $repo_slug );
+
+		if ( $reset ) {
+			$this->update_option( $repo_slug . '_full_sync', null );
+		}
 
 		/**
 		 * First, let's get info about the sync.

--- a/core.ghactivity.php
+++ b/core.ghactivity.php
@@ -662,9 +662,10 @@ class GHActivity_Calls {
 	 * @return bool $done Returns true when done.
 	 */
 	public function full_issue_sync( $repo_slug, $reset = false ) {
-		error_log( 'FULL ISSUE SYNC STARTED FOR' . $repo_slug );
+		error_log( 'FULL ISSUE SYNC STARTED FOR ' . $repo_slug );
 
-		if ( $reset ) {
+		if ( true === $reset ) {
+			error_log( 'RESETING STATUS FOR ' . $repo_slug );
 			$this->update_option( $repo_slug . '_full_sync', null );
 		}
 

--- a/github.ghactivity.php
+++ b/github.ghactivity.php
@@ -222,6 +222,7 @@ class GHActivity_GHApi {
 
 	/**
 	 * Remote call to get all open issues for specified repo
+	 * Additional parms can any of these: https://developer.github.com/v3/issues/#parameters
 	 *
 	 * @since 2.1.0
 	 *
@@ -230,13 +231,14 @@ class GHActivity_GHApi {
 	 *
 	 * @return array
 	 */
-	public function get_github_issues( $repo_name, $page_number = 1, $issues_state = 'open' ) {
+	public function get_github_issues( $repo_name, $page_number = 1, $issues_state = 'open', $additional_params = '' ) {
 		$query_url = sprintf(
-			'https://api.github.com/repos/%1$s/issues?access_token=%2$s&page=%3$s&per_page=100&state=%4$s',
+			'https://api.github.com/repos/%1$s/issues?access_token=%2$s&page=%3$s&per_page=100&state=%4$s%5$s',
 			esc_html( $repo_name ),
 			$this->token,
 			$page_number,
-			$issues_state
+			$issues_state,
+			urlencode( $additional_params )
 		);
 		return $this->get_github_data( $query_url );
 	}

--- a/github.ghactivity.php
+++ b/github.ghactivity.php
@@ -164,7 +164,7 @@ class GHActivity_GHApi {
 	 *
 	 * @return int $issues_number Number of open issues.
 	 */
-	public function get_repo_issues_count( $repo_name ) {
+	public function get_repo_open_issues_count( $repo_name ) {
 		if ( empty( $repo_name ) ) {
 			// Fallback.
 			return 0;
@@ -214,7 +214,7 @@ class GHActivity_GHApi {
 				esc_html( $issue_number ? '/' . $issue_number : '' ),
 				$this->token
 			);
-			$single_response_body = $this->get_all_github_data( $query_url );
+			$single_response_body = $this->get_all_github_data( $query_url, array(), 500 );
 			$response_body        = array_merge( $single_response_body, $response_body );
 		}
 		return $response_body;
@@ -306,10 +306,11 @@ class GHActivity_GHApi {
 	 *
 	 * @param string $query_url GitHub API URL to hit.
 	 * @param array  $headers Additional headers.
+	 * @param array  $max_results Maximum number of results you want to get. Useful when fetching endpoints with "endless" data.
 	 *
 	 * @return array $response_body Response body for each call.
 	 */
-	public function get_all_github_data( $query_url, $headers = array() ) {
+	public function get_all_github_data( $query_url, $headers = array(), $max_results = null ) {
 		$page        = 1;
 		$all_results = array();
 		// Fetch API until empty array will be returned.
@@ -318,7 +319,13 @@ class GHActivity_GHApi {
 			$body            = $this->get_github_data( $paged_query_url, $headers );
 			$all_results     = array_merge( $all_results, $body );
 			$page++;
-		} while ( ! empty( $body ) );
+
+			// We want to get all the data in case $max_results is null.
+			$condition = ! empty( $body );
+			if ( isset( $max_results ) ) {
+				$condition = ! empty( $body ) || count( $all_results );
+			}
+		} while ( $condition );
 		return $all_results;
 	}
 

--- a/js/admin-settings.js
+++ b/js/admin-settings.js
@@ -35,4 +35,26 @@ jQuery( document ).ready( function( $ ) {
 			$( '#ghactivity_redo_graphs_output' ).html( response ).show();
 		});
 	});
+
+	$( '.reset_sync_status' ).on( 'click', function( e ) {
+		// Get the name of the repo we will need to synchronize.
+		var repo_id = $(this).attr( 'id' );
+		var repo    = repo_id.replace('_reset_sync_status','');
+
+		// Make a query to our custom endpoint to launch sync.
+		$.ajax({
+			url: ghactivity_settings.api_url + 'ghactivity/v1/sync/' + repo + '?reset=true',
+			method: 'POST',
+			beforeSend : function( xhr ) {
+				xhr.setRequestHeader( 'X-WP-Nonce', ghactivity_settings.api_nonce );
+			}
+		}).done( function ( response ) {
+			$( '#' + repo_id ).remove();
+			$( '#' + repo_id ).attr( 'value', '' );
+			$( '#' + repo_id ).removeClass( 'disabled' );
+			$( '#' + repo + '_full_sync_details' ).html( response ).hide();
+
+			console.log(response);
+		});
+	});
 });

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<ruleset name="GHActivity">
+	<config name="minimum_supported_wp_version" value="4.7" />
+	<!-- <config name="testVersion" value="5.2-"/> -->
+
+	<!-- <rule ref="PHPCompatibility" /> -->
+	<rule ref="WordPress-Core" />
+	<rule ref="WordPress-Docs" />
+	<rule ref="WordPress-Extra" />
+	<rule ref="VariableAnalysis" />
+
+	<!-- Check all PHP files in directory tree by default. -->
+	<arg name="extensions" value="php"/>
+	<file>.</file>
+
+	<!-- Show sniff codes in all reports -->
+	<arg value="s"/>
+
+	<arg name="colors"/>
+
+	<exclude-pattern>/node_modules/*</exclude-pattern>
+	<exclude-pattern>/tests/*</exclude-pattern>
+	<exclude-pattern>/vendor/*</exclude-pattern>
+	<exclude-pattern>/_build/*</exclude-pattern>
+</ruleset>

--- a/rest.ghactivity.php
+++ b/rest.ghactivity.php
@@ -459,7 +459,7 @@ class Ghactivity_Api {
 					update_option( 'gha_remove_duplicate_issues_' . $name, $parsed_issues );
 				} else {
 					error_log( 'Trashing: ' . $name . ' :: ' . $issue_number . ' :: ' . $post_id );
-					wp_trash_post( $post_id, true );
+					wp_trash_post( $post_id );
 				}
 			}
 		}

--- a/rest.ghactivity.php
+++ b/rest.ghactivity.php
@@ -378,7 +378,7 @@ class Ghactivity_Api {
 		}
 
 		// [average_time, date_of_record, recorded_issues]
-		$records = GHActivity_Queries::fetch_average_label_time( $id, null );
+		$records = GHActivity_Queries::fetch_average_label_time( $id );
 
 		$response = array(
 			'id'      => $id,

--- a/rest.ghactivity.php
+++ b/rest.ghactivity.php
@@ -34,7 +34,7 @@ class Ghactivity_Api {
 		 *
 		 * @since 2.0.0
 		 */
-		register_rest_route( 'ghactivity/v1', '/sync/(?P<repo>[a-zA-Z0-9-]+)', array(
+		register_rest_route( 'ghactivity/v1', '/sync/(?P<repo>[0-9a-z\-_\/]+)', array(
 			'methods'             => WP_REST_Server::EDITABLE,
 			'callback'            => array( $this, 'trigger_sync' ),
 			'permission_callback' => array( $this, 'permissions_check' ),
@@ -177,6 +177,16 @@ class Ghactivity_Api {
 		if ( empty( $repos_to_monitor ) ) {
 			return new WP_REST_Response(
 				esc_html__( 'You currently do not monitor activity on any repository. You cannot use this option yet.', 'ghactivity' ),
+				200
+			);
+		}
+
+		// Reset full sync status.
+		if ( isset( $options[ $repo . '_full_sync' ], $request['reset'] ) && 'true' === $request['reset'] ) {
+			unset( $options[ $repo . '_full_sync' ] );
+			update_option( 'ghactivity', $options );
+			return new WP_REST_Response(
+				esc_html__( 'Full sync status reset', 'ghactivity' ),
 				200
 			);
 		}


### PR DESCRIPTION
AverageLabelTime for multiple labels is not reliable due to a few reasons: 
1. Not all issues are synced up with GitHub;
2. Initial implementation of multiple labeled ALT (#30) wasn't really smart for cases when one of the labels was unlabeled;
3. GitHub Events API returns historical events, meaning label names in these events matching to original values, and does not include updated (renamed) label names. 

This PR is fixing the first two points, while the third point can be only fixed manually via re-labeling.

What is done is this PR: 
- I've removed  "Trigger Label Rescan" button and related code from an admin settings page (fc47d6b3c4e81d69bf0ad136a9384f1734e23b36 & 8f4461bf3dafcdcef62d984a394bd6aa76c5941f)
- Instead, I included label rescan functionality into Repo Sync task (019f78c46c5d4caaead4228412d7097d9d9671d8)
- Added a way to reset Repo Sync status via a button in the admin settings page
- Fixed the bug in `current_average_label_time` for multiple labels (1080078ae1e478a7f001c8e1089a8eb090b5ca92)
- Added PHPCS into the project (ead225ad04b476ec33bcb13da43cd6ce916179bd)
